### PR TITLE
Marshmallow Based Event Schema Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .tox
+.cache
+.vscode
 dist
 venv
+cq.egg-info
 *.pyc
 *.log
 *.bak

--- a/cq/aggregates.py
+++ b/cq/aggregates.py
@@ -42,8 +42,8 @@ class Aggregate:
         schema = schema_cls()
         result = schema.load(event_data)
         if result.errors:
-            msg = "Error validatng %s.%s event. Details: %s." % (cls.get_name(), event_name, result.errors)
-            raise SchemaValidationError(msg)
+            msg = "Error validatng %s.%s event" % (cls.get_name(), event_name)
+            raise SchemaValidationError(msg, result.errors)
 
         return True
 

--- a/cq/aggregates.py
+++ b/cq/aggregates.py
@@ -37,13 +37,15 @@ class Aggregate:
     def validate(cls, event_name, event_data):
         schema_cls = cls.get_schema(event_name)
         if not schema_cls:
-            return
+            return True
 
         schema = schema_cls()
         result = schema.load(event_data)
         if result.errors:
             msg = "Error validatng %s.%s event. Details: %s." % (cls.get_name(), event_name, result.errors)
             raise SchemaValidationError(msg)
+
+        return True
 
     @classmethod
     def get_schema(cls, name):

--- a/cq/exceptions.py
+++ b/cq/exceptions.py
@@ -6,3 +6,7 @@ class SesError(Exception):
 
 class ImproperlyConfigured(SesError):
     pass
+
+
+class SchemaValidationError(Exception):
+    pass

--- a/cq/exceptions.py
+++ b/cq/exceptions.py
@@ -9,4 +9,10 @@ class ImproperlyConfigured(SesError):
 
 
 class SchemaValidationError(Exception):
-    pass
+    def __init__(self, message, errors):
+        super().__init__(message)
+        self.errors = errors
+
+    def __str__(self):
+        err = super().__str__()
+        return "%s: %s" % (err, self.errors)

--- a/cq/schemas.py
+++ b/cq/schemas.py
@@ -1,19 +1,10 @@
-from marshmallow import Schema, fields
+"""
+Event schema validation code.
+Currently this is mostly light abstraction over `marshmallow`.
+"""
+from marshmallow import fields
+from marshmallow import Schema as _Schema
 
-__all__ = ['register_schema', 'Schema', 'fields']
+EventSchema = _Schema
 
-
-def register_schema(aggregate_class, event_name):
-
-    def outer(method):
-        if not hasattr(aggregate_class, 'schemas'):
-            aggregate_class.schemas = {}
-
-        if event_name in aggregate_class.schemas:
-            msg = "Schema for action %s is already registered for %s" % (event_name, aggregate_class)
-            raise RuntimeError(msg)
-        else:
-            aggregate_class.schemas[event_name] = method
-        return method
-
-    return outer
+__all__ = ['EventSchema', 'fields']

--- a/cq/schemas.py
+++ b/cq/schemas.py
@@ -1,0 +1,19 @@
+from marshmallow import Schema, fields
+
+__all__ = ['register_schema', 'Schema', 'fields']
+
+
+def register_schema(aggregate_class, event_name):
+
+    def outer(method):
+        if not hasattr(aggregate_class, 'schemas'):
+            aggregate_class.schemas = {}
+
+        if event_name in aggregate_class.schemas:
+            msg = "Schema for action %s is already registered for %s" % (event_name, aggregate_class)
+            raise RuntimeError(msg)
+        else:
+            aggregate_class.schemas[event_name] = method
+        return method
+
+    return outer

--- a/cq/schemas.py
+++ b/cq/schemas.py
@@ -14,6 +14,7 @@ __all__ = ['EventSchema', 'fields']
 class EventSchema(_Schema):
     @validates_schema(pass_original=True)
     def check_unknown_fields(self, data, original_data):
+        original_data = original_data or {}
         unknown = set(original_data) - set(self.fields)
         if unknown:
             raise ValidationError('Unknown field', unknown)

--- a/cq/schemas.py
+++ b/cq/schemas.py
@@ -4,7 +4,16 @@ Currently this is only light abstraction over `marshmallow`.
 """
 from marshmallow import fields
 from marshmallow import Schema as _Schema
+from marshmallow import validates_schema
+from marshmallow import ValidationError
 
-EventSchema = _Schema
 
 __all__ = ['EventSchema', 'fields']
+
+
+class EventSchema(_Schema):
+    @validates_schema(pass_original=True)
+    def check_unknown_fields(self, data, original_data):
+        unknown = set(original_data) - set(self.fields)
+        if unknown:
+            raise ValidationError('Unknown field', unknown)

--- a/cq/schemas.py
+++ b/cq/schemas.py
@@ -1,6 +1,6 @@
 """
 Event schema validation code.
-Currently this is mostly light abstraction over `marshmallow`.
+Currently this is only light abstraction over `marshmallow`.
 """
 from marshmallow import fields
 from marshmallow import Schema as _Schema

--- a/cq/tests/app.py
+++ b/cq/tests/app.py
@@ -1,6 +1,7 @@
 import cq.aggregates
 import cq.app
 import cq.handlers
+import cq.schemas
 
 
 def add_password(event):
@@ -22,15 +23,24 @@ class User(cq.aggregates.Aggregate):
         cq.aggregates.upcaster('User', 'Registered', revision=2, method=add_role),
     ]
 
+class UserRegisteredSchema(cq.schemas.EventSchema):
+    email = cq.schemas.fields.Email()
+    password = cq.schemas.fields.Str()
+    role = cq.schemas.fields.Str()
 
-@cq.aggregates.register_mutator(User, 'Registered')
+
+class UserEmailChangedSchema(cq.schemas.EventSchema):
+    email = cq.schemas.fields.Email()
+
+
+@cq.aggregates.register_mutator(User, 'Registered', schema=UserRegisteredSchema)
 def mutate_registered(instance, event, data):
     instance.email = data['email']
     instance.password = data['password']
     instance.role = data['role']
 
 
-@cq.aggregates.register_mutator(User, 'EmailChanged')
+@cq.aggregates.register_mutator(User, 'EmailChanged', schema=UserEmailChangedSchema)
 def mutate_email_changed(instance, event, data):
     instance.email = data['email']
 

--- a/cq/tests/test_aggregates.py
+++ b/cq/tests/test_aggregates.py
@@ -1,5 +1,6 @@
 from .app import Accounts
 import cq.aggregates
+import pytest
 
 
 class User(cq.aggregates.Aggregate):
@@ -30,3 +31,14 @@ def test_aggregate_is_rehydrated_with_upcasted_events():
     accounts.storage.store('User', 'Registered', user_id, data={'email': 'joe@doe.com'})
     user = accounts.users.get_aggregate(user_id)
     assert user.role == 'user'
+
+
+class AggregateWithoutMutators(cq.aggregates.Aggregate):
+        pass
+
+
+def test_aggregate_get_mutators__none_registered():
+    with pytest.raises(NotImplementedError) as excinfo:
+        AggregateWithoutMutators.get_mutator('dummy_mutator')
+    
+    assert 'no mutator function registered for event' in str(excinfo.value)

--- a/cq/tests/test_apps.py
+++ b/cq/tests/test_apps.py
@@ -3,7 +3,7 @@ from .app import Accounts
 
 def test_aggregate_version_is_bumped():
     accounts = Accounts()
-    user_id = accounts.register('joe@doe.com').aggregate_id
+    user_id = accounts.register('joe@doe.com', password='secret').aggregate_id
     user = accounts.get(user_id)
 
     assert user.email == 'joe@doe.com'

--- a/cq/tests/test_schemas.py
+++ b/cq/tests/test_schemas.py
@@ -2,6 +2,7 @@ from .app import User
 from .app import UserRegisteredSchema
 from .app import UserEmailChangedSchema
 import cq.aggregates
+import cq.exceptions
 import cq.schemas
 import pytest
 
@@ -23,3 +24,21 @@ def test_user_aggregate_registered_schemas():
 
 def test_user_aggreagate_get_schemas():
     assert User.get_schema('dummy_schema') is None
+
+
+def test_validate_user_registered__valid_data():
+    assert True is User.validate('Registered', {
+        'email': 'john@doe.com',
+        'password': 'secret',
+        'role': 'janitor'
+    })
+
+
+def test_validate_user_registered__invalid_data():
+    with pytest.raises(cq.exceptions.SchemaValidationError) as exc:
+        User.validate('Registered', {
+            'email': 'dummy',
+        })
+
+    msg = "Error validatng User.Registered event. Details: {'email': ['Not a valid email address.']}."
+    assert msg in str(exc.value)

--- a/cq/tests/test_schemas.py
+++ b/cq/tests/test_schemas.py
@@ -1,0 +1,25 @@
+from .app import User
+from .app import UserRegisteredSchema
+from .app import UserEmailChangedSchema
+import cq.aggregates
+import cq.schemas
+import pytest
+
+
+class AggregateWithoutMutators(cq.aggregates.Aggregate):
+        pass
+
+
+def test_aggregate_get_schema__none_mutators_registered():
+    assert AggregateWithoutMutators.get_schema('dummy_mutator') is None
+    
+
+def test_user_aggregate_registered_schemas():
+    assert User.schemas == {
+        'Registered': UserRegisteredSchema,
+        'EmailChanged': UserEmailChangedSchema,
+    }
+
+
+def test_user_aggreagate_get_schemas():
+    assert User.get_schema('dummy_schema') is None

--- a/cq/tests/test_schemas.py
+++ b/cq/tests/test_schemas.py
@@ -40,7 +40,7 @@ def test_validate_user_registered__invalid_data():
             'email': 'dummy',
         })
 
-    msg = "Error validatng User.Registered event. Details: {'email': ['Not a valid email address.']}"
+    msg = "Error validatng User.Registered event: {'email': ['Not a valid email address.']}"
     assert msg in str(exc.value)
 
 
@@ -56,5 +56,5 @@ def test_validate_user_registered__excess_keys():
             'unrelated': 'info'
         })
 
-    msg = "Error validatng User.Registered event. Details: {'unrelated': ['Unknown field']}."
+    msg = "Error validatng User.Registered event: {'unrelated': ['Unknown field']}"
     assert msg in str(exc.value)

--- a/cq/tests/test_schemas.py
+++ b/cq/tests/test_schemas.py
@@ -27,7 +27,7 @@ def test_user_aggreagate_get_schemas():
 
 
 def test_validate_user_registered__valid_data():
-    assert True is User.validate('Registered', {
+    assert User.validate('Registered', {
         'email': 'john@doe.com',
         'password': 'secret',
         'role': 'janitor'
@@ -40,5 +40,21 @@ def test_validate_user_registered__invalid_data():
             'email': 'dummy',
         })
 
-    msg = "Error validatng User.Registered event. Details: {'email': ['Not a valid email address.']}."
+    msg = "Error validatng User.Registered event. Details: {'email': ['Not a valid email address.']}"
+    assert msg in str(exc.value)
+
+
+def test_validate_user_registered__excess_keys():
+    """
+    Strictly report errors if unspecified keys are provided in event payload.
+    """
+    with pytest.raises(cq.exceptions.SchemaValidationError) as exc:
+        assert User.validate('Registered', {
+            'email': 'john@doe.com',
+            'password': 'secret',
+            'role': 'janitor',
+            'unrelated': 'info'
+        })
+
+    msg = "Error validatng User.Registered event. Details: {'unrelated': ['Unknown field']}."
     assert msg in str(exc.value)

--- a/cq/tests/test_upcasting.py
+++ b/cq/tests/test_upcasting.py
@@ -6,8 +6,8 @@ from cq.genuuid import genuuid
 def test_event_is_upcasted():
     accounts = Accounts()
 
-    event = accounts.register('joe@doe.com')
-    assert event.data == {'email': 'joe@doe.com', 'role': 'user', 'password': None}
+    event = accounts.register('joe@doe.com', password='secret')
+    assert event.data == {'email': 'joe@doe.com', 'role': 'user', 'password': 'secret'}
     assert event.revision == 3
 
 

--- a/examples/djangoapp/accounts/aggregates.py
+++ b/examples/djangoapp/accounts/aggregates.py
@@ -22,17 +22,14 @@ class UserRegisteredSchema(EventSchema):
 
 
 class ActivatedWithTokenSchema(EventSchema):
-    # TODO: Make sure this make sure that the even body is empty?
     pass
 
 
 class ActivatedSchema(EventSchema):
-    # TODO: Make sure this make sure that the even body is empty?
     pass
 
 
 class InactivatedSchema(EventSchema):
-    # TODO: Make sure this make sure that the even body is empty?
     pass
 
 

--- a/examples/djangoapp/accounts/aggregates.py
+++ b/examples/djangoapp/accounts/aggregates.py
@@ -1,8 +1,7 @@
 from cq.aggregates import Aggregate
 from cq.aggregates import register_mutator
-from cq.schemas import Schema
+from cq.schemas import EventSchema
 from cq.schemas import fields
-from cq.schemas import register_schema
 
 
 class User(Aggregate):
@@ -15,35 +14,33 @@ class User(Aggregate):
         return self.is_active
 
 
-@register_schema(User, 'Registered')
-class UserRegisteredSchema(Schema):
-    email = fields.Number()
+class UserRegisteredSchema(EventSchema):
+    email = fields.Email()
     encoded_password = fields.Str()
     activation_token = fields.Str()
     role = fields.Str()
 
 
-@register_schema(User, 'ActivatedWithToken')
-class ActivatedWithTokenSchema(Schema):
+class ActivatedWithTokenSchema(EventSchema):
+    # TODO: Make sure this make sure that the even body is empty?
     pass
 
 
-@register_schema(User, 'Activated')
-class ActivatedSchema(Schema):
+class ActivatedSchema(EventSchema):
+    # TODO: Make sure this make sure that the even body is empty?
     pass
 
 
-@register_schema(User, 'Inactivated')
-class InactivatedSchema(Schema):
+class InactivatedSchema(EventSchema):
+    # TODO: Make sure this make sure that the even body is empty?
     pass
 
 
-@register_schema(User, 'ObtainedAuthToken')
-class ObtainedAuthTokenSchema(Schema):
+class ObtainedAuthTokenSchema(EventSchema):
     auth_token = fields.Str()
 
 
-@register_mutator(User, 'Registered')
+@register_mutator(User, 'Registered', schema=UserRegisteredSchema)
 def mutate_registered(aggregate, event, data):
     aggregate.email = data['email']
     aggregate.encoded_password = data['encoded_password']
@@ -51,25 +48,25 @@ def mutate_registered(aggregate, event, data):
     aggregate.is_active = False
 
 
-@register_mutator(User, 'ActivatedWithToken')
+@register_mutator(User, 'ActivatedWithToken', schema=ActivatedWithTokenSchema)
 def mutate_activated_with_token(aggregate, event, data):
     aggregate.is_active = True
     aggregate.activation_token = None
 
 
-@register_mutator(User, 'Activated')
+@register_mutator(User, 'Activated', schema=ActivatedSchema)
 def mutate_activated(aggregate, event, data):
     aggregate.is_active = True
     aggregate.activation_token = None
 
 
-@register_mutator(User, 'Inactivated')
+@register_mutator(User, 'Inactivated', schema=InactivatedSchema)
 def mutate_inactivated(aggregate, event, data):
     aggregate.is_active = False
     aggregate.activation_token = None
 
 
-@register_mutator(User, 'ObtainedAuthToken')
+@register_mutator(User, 'ObtainedAuthToken', schema=ObtainedAuthTokenSchema)
 def mutate_obtained_auth_token(aggregate, event, data):
     aggregate.auth_token = data['auth_token']
 

--- a/examples/djangoapp/accounts/aggregates.py
+++ b/examples/djangoapp/accounts/aggregates.py
@@ -1,5 +1,8 @@
 from cq.aggregates import Aggregate
 from cq.aggregates import register_mutator
+from cq.schemas import Schema
+from cq.schemas import fields
+from cq.schemas import register_schema
 
 
 class User(Aggregate):
@@ -10,6 +13,34 @@ class User(Aggregate):
         Mimics what original Django's auth.User does
         """
         return self.is_active
+
+
+@register_schema(User, 'Registered')
+class UserRegisteredSchema(Schema):
+    email = fields.Number()
+    encoded_password = fields.Str()
+    activation_token = fields.Str()
+    role = fields.Str()
+
+
+@register_schema(User, 'ActivatedWithToken')
+class ActivatedWithTokenSchema(Schema):
+    pass
+
+
+@register_schema(User, 'Activated')
+class ActivatedSchema(Schema):
+    pass
+
+
+@register_schema(User, 'Inactivated')
+class InactivatedSchema(Schema):
+    pass
+
+
+@register_schema(User, 'ObtainedAuthToken')
+class ObtainedAuthTokenSchema(Schema):
+    auth_token = fields.Str()
 
 
 @register_mutator(User, 'Registered')

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'jsonfield',  # TODO: only needed django, make it optional
-        'marshmallow==2.13.5',
+        'marshmallow>=2.13',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'jsonfield',  # TODO: only needed django, make it optional
+        'marshmallow==2.13.5',
     ],
 )


### PR DESCRIPTION
Coversation of the discussion started in: https://github.com/lukaszb/cq/pull/21

I know that for now this looks super ugly but wanted to get your feedback on:

* Placement of the validation code. Validation is controlled by `Repository` class. 
* How do you like the Schema registration API? It mimics what is done for mutators.
* Do you like the fact that only event data is validated (static fields of an event are skipped to avoid repetetive work).

Things that needs to be changed if we agree on the points above:
* Decide where to place schema definitions in examples (`schema.py` ?).
* Add tests
* Relax the setup.py import
* Strict mode to enforce validation (?)


